### PR TITLE
Fix/cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solid Calendar Store
 
-Solid Calendar is a plugin for [CSS](https://github.com/solid/community-server). 
+Solid Calendar is a plugin for [CSS](https://github.com/solid/community-server).
 It adds the possibility to perform a list of calendar-based operations.
 For a concrete overview of all the possible transformations and conversions see `docs/`.
 
@@ -24,6 +24,8 @@ See the [CSS documentation](https://github.com/solid/community-server#configurin
 
 ## Endpoints
 
+These endpoints are the default provided ones, see `config/config-calendar.json` to see how they're set up and to add your own.
+
 | Type | Name           | Used store          |
 | ---- | -------------- | ------------------- |
 | GET  | calendar       | CalendarStore       |
@@ -31,6 +33,8 @@ See the [CSS documentation](https://github.com/solid/community-server#configurin
 | GET  | availability   | AvailabilityStore   |
 | GET  | aggregate      | AggregateStore      |
 | GET  | transformation | TransformationStore |
+| GET  | holidays       | HolidayStore        |
+| GET  | holidays/busy  | ExtendedBusyStore   |
 
 ## my-settings.yaml
 
@@ -91,3 +95,25 @@ These are then structured in a json file like this:
 ```
 
 See `docs/stores.md` for places where the holidays are used.
+
+## Calendar JSON format
+
+For the calendar name the `X-WR-CALNAME` field is used.  
+Not all possible event fields of an ICS calendar are used. The following are required: `summary`, `dtstart` and `dtend`, these are optional: `description` and `location`.
+
+This results in the following format:
+
+```ts
+{
+    name: string,
+    events: [
+        {
+            title: string,
+            startDate: Date,
+            endDate: Date,
+            location?: string,
+            description?: string
+        }
+    ]
+}
+```

--- a/config.json
+++ b/config.json
@@ -1,20 +1,20 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "https://calendar.google.com/calendar/ical/ihqfct3hddiiskgvujr3df2pe0%40group.calendar.google.com/public/basic.ics"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "settings/my-settings.yaml",
-      "AvailabilityStore:_options_holidaySource": { "@id": "solid-calendar:HolidayStore" }
+      "AvailabilityStore:_options_holidaySource": { "@id": "solid-calendar-store:HolidayStore" }
     }
   ]
 }

--- a/config/config-calendar.json
+++ b/config/config-calendar.json
@@ -1,10 +1,10 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^0.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@rmlio/solid-rml-store/^0.0.0/components/context.jsonld",
     {
-      "solid-calendar": "urn:solid-calendar:default:",
+      "solid-calendar-store": "urn:solid-calendar-store:default:",
       "solid-server": "urn:solid-server:default:",
       "solid-rml-store": "urn:solid-rml-store:default:"
     }
@@ -68,31 +68,31 @@
       "storeMap": [
         {
           "RegexRouterRule:_storeMap_key": "^/holidays/busy$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:ExtendedBusyStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:ExtendedBusyStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/holidays(/)?$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:HolidayStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:HolidayStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/calendar$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:CalendarStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:CalendarStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/availability$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:AvailabilityStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:AvailabilityStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/busy$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:BusyStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:BusyStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/aggregate$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:AggregateStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:AggregateStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/transformation$",
-          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar:TransformationStore" }
+          "RegexRouterRule:_storeMap_value": { "@id": "solid-calendar-store:TransformationStore" }
         },
         {
           "RegexRouterRule:_storeMap_key": "^/(\\.acl)?$",
@@ -108,15 +108,15 @@
       "accessor": { "@id": "solid-server:MemoryDataAccessor" }
     },
     {
-      "@id": "solid-calendar:TransformationStore",
+      "@id": "solid-calendar-store:TransformationStore",
       "@type": "TransformationStore",
       "TransformationStore:_source": {
-        "@id": "solid-calendar:CalendarStore"
+        "@id": "solid-calendar-store:CalendarStore"
       },
       "TransformationStore:_options_settingsPaths": ["settings/busy.yaml"]
     },
     {
-      "@id": "solid-calendar:RDFStore",
+      "@id": "solid-calendar-store:RDFStore",
       "@type": "RDFStore"
     },
     {
@@ -125,71 +125,71 @@
       "AnyToRdfConverter:_rmlmapperPath": "./rmlmapper.jar"
     },
     {
-      "@id": "solid-calendar:IcsToJsonConverter",
+      "@id": "solid-calendar-store:IcsToJsonConverter",
       "@type": "IcsToJsonConverter"
     },
     {
-      "@id": "solid-calendar:JsonToIcsConverter",
+      "@id": "solid-calendar-store:JsonToIcsConverter",
       "@type": "JsonToIcsConverter"
     },
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "@type": "HttpGetStore"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "@type": "AvailabilityStore",
       "AvailabilityStore:_source": {
-        "@id": "solid-calendar:CalendarStore"
+        "@id": "solid-calendar-store:CalendarStore"
       },
       "AvailabilityStore:_options_baseUrl": "http://example.com/"
     },
     {
-      "@id": "solid-calendar:ExtendedBusyStore",
+      "@id": "solid-calendar-store:ExtendedBusyStore",
       "@type": "AggregateStore",
-      "AggregateStore:_source1": { "@id": "solid-calendar:BusyStore" },
-      "AggregateStore:_source2": { "@id": "solid-calendar:HolidayStore"}
+      "AggregateStore:_source1": { "@id": "solid-calendar-store:BusyStore" },
+      "AggregateStore:_source2": { "@id": "solid-calendar-store:HolidayStore"}
     },
     {
-      "@id": "solid-calendar:HolidayStore",
+      "@id": "solid-calendar-store:HolidayStore",
       "@type": "HolidayStore",
       "HolidayStore:_options_configPath": "./settings/default-holidays.json"
     },
     {
-      "@id": "solid-calendar:BusyStore",
+      "@id": "solid-calendar-store:BusyStore",
       "@type": "TransformationStore",
       "TransformationStore:_options_rules": ["busy"],
       "TransformationStore:_source": {
-        "@id": "solid-calendar:CalendarStore"
+        "@id": "solid-calendar-store:CalendarStore"
       },
       "TransformationStore:_options_settingsPaths": ["settings/busy.yaml"]
     },
     {
-      "@id": "solid-calendar:AggregateStore",
+      "@id": "solid-calendar-store:AggregateStore",
       "@type": "AggregateStore",
       "AggregateStore:_source1": {
-        "@id": "solid-calendar:CalendarStore"
+        "@id": "solid-calendar-store:CalendarStore"
       },
       "AggregateStore:_source2": {
-        "@id": "solid-calendar:CalendarStore"
+        "@id": "solid-calendar-store:CalendarStore"
       }
     },
     {
-      "@id": "solid-calendar:CalendarStore",
+      "@id": "solid-calendar-store:CalendarStore",
       "@type": "RepresentationConvertingStore",
       "RepresentationConvertingStore:_source": {
-        "@id": "solid-calendar:HttpGetStore"
+        "@id": "solid-calendar-store:HttpGetStore"
       },
       "RepresentationConvertingStore:_options_outConverter": {
-        "@id": "solid-calendar:RepresentationConverter"
+        "@id": "solid-calendar-store:RepresentationConverter"
       }
     },
     {
-      "@id": "solid-calendar:RdfRepresentationConverter",
+      "@id": "solid-calendar-store:RdfRepresentationConverter",
       "@type": "ChainedConverter",
       "ChainedConverter:_converters": [
         {
-          "@id": "solid-calendar:IcsToJsonConverter"
+          "@id": "solid-calendar-store:IcsToJsonConverter"
         },
         {
           "@id": "solid-rml-store:AnyToRdfConverter"
@@ -197,7 +197,7 @@
       ]
     },
     {
-      "@id": "solid-calendar:RepresentationConverter",
+      "@id": "solid-calendar-store:RepresentationConverter",
       "@type": "WaterfallHandler",
       "WaterfallHandler:_handlers": [
         {
@@ -214,10 +214,10 @@
           "@id": "solid-rml-store:AnyToRdfConverter"
         },
         {
-          "@id": "solid-calendar:IcsToJsonConverter"
+          "@id": "solid-calendar-store:IcsToJsonConverter"
         },
         {
-          "@id": "solid-calendar:RdfRepresentationConverter"
+          "@id": "solid-calendar-store:RdfRepresentationConverter"
         }
       ]
     }

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -23,6 +23,11 @@ It first reads the yaml file specified in `config.json`, then generates the avai
 
 No timeslots are generated on a weekend and on a holiday.
 
+### Internalisation
+
+There are 2 optional fields, `weekend` and `timezone`. Their default values are resp. `[0, 6]` (Sunday and Saturday in UTC) and `Europe/Brussels`.
+The times written in `availabilitySlots` are written in the specified timezone, these will then be converted to UTC. See [this](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of all the possible timezones.
+
 ## TransformationStore
 
 _type: TransformationStore_
@@ -46,6 +51,7 @@ _type: AggregateStore_
 [![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggTFJcbiAgICBBW1Jlc291cmNlSWRlbnRpZmllcl0gLS0-IHxDYWxlbmRhclN0b3JlfEIoUmVwcmVzZW50YXRpb248dGV4dC9jYWxlbmRhcj4pXG4gICAgQiAtLT4gfEFnZ3JlZ2F0ZVN0b3JlfEMoUmVwcmVzZW50YXRpb248SlNPTj4pXG4gICAgRFtSZXNvdXJjZUlkZW50aWZpZXJdIC0tPiB8Q2FsZW5kYXJTdG9yZXxFKFJlcHJlc2VudGF0aW9uPHRleHQvY2FsZW5kYXI-KVxuICAgIEUgLS0-IEMiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlLCJhdXRvU3luYyI6dHJ1ZSwidXBkYXRlRGlhZ3JhbSI6ZmFsc2V9)](https://mermaid-js.github.io/mermaid-live-editor/edit/##eyJjb2RlIjoiZ3JhcGggTFJcbiAgICBBW1Jlc291cmNlSWRlbnRpZmllcl0gLS0-IHxDYWxlbmRhclN0b3JlfEIoUmVwcmVzZW50YXRpb248dGV4dC9jYWxlbmRhcj4pXG4gICAgQiAtLT4gfEFnZ3JlZ2F0ZVN0b3JlfEMoUmVwcmVzZW50YXRpb248SlNPTj4pXG4gICAgRFtSZXNvdXJjZUlkZW50aWZpZXJdIC0tPiB8Q2FsZW5kYXJTdG9yZXxFKFJlcHJlc2VudGF0aW9uPHRleHQvY2FsZW5kYXI-KVxuICAgIEUgLS0-IENcbiAgICAiLCJtZXJtYWlkIjoie1xuICBcInRoZW1lXCI6IFwiZGVmYXVsdFwiXG59IiwidXBkYXRlRWRpdG9yIjpmYWxzZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOmZhbHNlfQ)
 
 Converts 2 representations to `JSON` and concats them. The title of each now also has the calendar name prepended to it, e.g. `[name] event`.
+Default aggregated calendar name is: `Aggregated calendar of ${source1} and ${source2}`, but this can be overwritten.
 
 ## HolidayStore
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "solid-calendar",
+  "name": "solid-calendar-store",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "solid-calendar-store",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,15 +62,15 @@
     "luxon": "^1.26.0",
     "node-fetch": "^2.6.1"
   },
-  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store",
   "lsd:components": "dist/components/components.jsonld",
   "lsd:contexts": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld": "dist/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld": "dist/components/context.jsonld"
   },
   "lsd:importPaths": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/": "dist/components/",
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/config/": "config/",
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/dist/": "dist/"
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/": "dist/components/",
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/config/": "config/",
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/dist/": "dist/"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/aggregate-store.ts
+++ b/src/aggregate-store.ts
@@ -11,6 +11,9 @@ const outputType = "application/json";
 const defaultCalendarName = (source1: string, source2: string) =>
   `Aggregated calendar of ${source1} and ${source2}`;
 
+/**
+ * Aggregates 2 calendar sources together
+ */
 export class AggregateStore extends BaseResourceStore {
   private source1: RepresentationConvertingStore;
   private source2: RepresentationConvertingStore;

--- a/src/aggregate-store.ts
+++ b/src/aggregate-store.ts
@@ -5,7 +5,6 @@ import {
   Representation,
   RepresentationConvertingStore,
   ResourceIdentifier,
-  NotFoundHttpError,
 } from "@solid/community-server";
 
 const outputType = "application/json";
@@ -43,9 +42,7 @@ export class AggregateStore extends BaseResourceStore {
 
     return new BasicRepresentation(
       JSON.stringify({
-        name: this.name
-          ? this.name
-          : defaultCalendarName(events1.name, events2.name),
+        name: this.name ?? defaultCalendarName(events1.name, events2.name),
         events: allEvents,
       }),
       outputType

--- a/src/availability-store.ts
+++ b/src/availability-store.ts
@@ -18,6 +18,9 @@ import { getUtcComponents } from "./date-utils";
 
 const outputType: string = "application/json";
 
+/**
+ * Generates availability slots based upon a YAML settings file
+ */
 export class AvailabilityStore extends PassthroughStore<HttpGetStore> {
   private readonly baseUrl: string;
   private availabilitySlots: [];

--- a/src/calendar-utils.ts
+++ b/src/calendar-utils.ts
@@ -78,11 +78,9 @@ export function createCalendar(title: string, uid: string, events: any[]) {
  *
  * @param baseUrl
  * @param busyEvents
- * @param slots
- * @param startDate
- * @param endDate
  * @param availabilitySlots - Array of default availability slots.
  * @param minimumSlotDuration - Minimum duration of a slot.
+ * @param options - Optional options that can be set
  */
 export function getAvailableSlots(
   baseUrl: string,
@@ -124,6 +122,7 @@ export function getAvailableSlots(
  * @param baseUrl - The url used to generate urls for the slots.
  * @param availabilitySlots - Array of default availability slots.
  * @param stampDate - The date at which the slots are generated.
+ * @param options - Optional options that can be set
  */
 export function getSlots(
   startDate: Date,
@@ -158,6 +157,7 @@ export function getSlots(
  * @param baseUrl - The url used to generate urls for the slots.
  * @param availabilitySlots - Array of default availability slots.
  * @param stampDate - The date at which the slots are generated.
+ * @param options - Optional options that can be set
  */
 export function createSlots(
   date: Date,

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -13,9 +13,10 @@ export function utcDate(year: number, month: number, days: number) {
   return new Date(Date.UTC(year, month, days));
 }
 
-export function inWeekend(date: Date) {
+export function inWeekend(date: Date, weekend?: number[]) {
+  const wnd = weekend ?? [0, 6];
   const day = date.getUTCDay();
-  return day === 6 || day === 0;
+  return wnd.some((w) => w === day);
 }
 
 /**

--- a/src/holiday-store.ts
+++ b/src/holiday-store.ts
@@ -27,7 +27,12 @@ export class HolidayStore extends BaseResourceStore {
     const holidays: { title: string; startDate: Date; endDate: Date }[] = [];
     const currentYear = new Date().getFullYear();
 
-    let constant, fluid, shifting;
+    let constant: { name: any; date: { month: number; day: number } }[],
+      fluid: { [s: string]: Date } | ArrayLike<Date>,
+      shifting: {
+        name: any;
+        date: { month: number; weekday: number; n: number };
+      }[];
     try {
       const json = await readJson(this.configPath);
 
@@ -40,17 +45,15 @@ export class HolidayStore extends BaseResourceStore {
       else throw e;
     }
 
-    if (constant !== undefined) {
-      constant.forEach(
-        (h: { name: any; date: { month: number; day: number } }) =>
-          holidays.push({
-            title: h.name,
-            ...this._getStartAndEndDate(
-              utcDate(currentYear, h.date.month, h.date.day)
-            ),
-          })
-      );
-    }
+    constant?.forEach(
+      (h: { name: any; date: { month: number; day: number } }) =>
+        holidays.push({
+          title: h.name,
+          ...this._getStartAndEndDate(
+            utcDate(currentYear, h.date.month, h.date.day)
+          ),
+        })
+    );
 
     if (fluid !== undefined) {
       (Object.entries(fluid) as [string, Date][]).forEach(([name, date]) => {
@@ -63,18 +66,13 @@ export class HolidayStore extends BaseResourceStore {
       });
     }
 
-    if (shifting !== undefined) {
-      shifting.forEach(
-        (h: {
-          name: any;
-          date: { month: number; weekday: number; n: number };
-        }) =>
-          holidays.push({
-            title: h.name,
-            ...this._getStartAndEndDate(processShiftingHoliday(h.date)),
-          })
-      );
-    }
+    shifting?.forEach(
+      (h: { name: any; date: { month: number; weekday: number; n: number } }) =>
+        holidays.push({
+          title: h.name,
+          ...this._getStartAndEndDate(processShiftingHoliday(h.date)),
+        })
+    );
 
     return new BasicRepresentation(
       JSON.stringify({ name: "Holiday", events: holidays }),

--- a/src/holiday-store.ts
+++ b/src/holiday-store.ts
@@ -11,6 +11,9 @@ import { processShiftingHoliday, utcDate } from "./date-utils";
 
 const outputType = "application/json";
 
+/**
+ * Generates a calendar of holidays based upon a JSON configuration file
+ */
 export class HolidayStore extends BaseResourceStore {
   private readonly configPath: string;
 

--- a/src/http-get-store.ts
+++ b/src/http-get-store.ts
@@ -1,27 +1,36 @@
-import {BaseResourceStore, BasicRepresentation, Representation, ResourceIdentifier} from "@solid/community-server";
-import fetch from 'node-fetch';
-import {RepresentationPreferences} from "@solid/community-server/dist/ldp/representation/RepresentationPreferences";
-const parseContentType = require('content-type').parse;
+import {
+  BaseResourceStore,
+  BasicRepresentation,
+  Representation,
+  ResourceIdentifier,
+} from "@solid/community-server";
+import fetch from "node-fetch";
+import { RepresentationPreferences } from "@solid/community-server/dist/ldp/representation/RepresentationPreferences";
+const parseContentType = require("content-type").parse;
 
+/**
+ * Fetches the resource at an URL
+ */
 export class HttpGetStore extends BaseResourceStore {
-    private readonly url: string;
+  private readonly url: string;
 
-    public constructor(options: {
-        url: string;
-    }) {
-        super();
-        this.url = options.url;
-    }
+  public constructor(options: { url: string }) {
+    super();
+    this.url = options.url;
+  }
 
-    /**
-     * Retrieves a JSON representation of events in the calender.
-     */
-    public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences): Promise<Representation> {
-        const response = await fetch(this.url);
-        const text = await response.text();
-        let contentType = response.headers.get('content-type') || 'text/plain';
-        contentType = parseContentType(contentType).type;
+  /**
+   * Retrieves a JSON representation of events in the calender.
+   */
+  public async getRepresentation(
+    identifier: ResourceIdentifier,
+    preferences: RepresentationPreferences
+  ): Promise<Representation> {
+    const response = await fetch(this.url);
+    const text = await response.text();
+    let contentType = response.headers.get("content-type") || "text/plain";
+    contentType = parseContentType(contentType).type;
 
-        return new BasicRepresentation(text, identifier, contentType);
-    }
+    return new BasicRepresentation(text, identifier, contentType);
+  }
 }

--- a/src/ics-to-json-converter.ts
+++ b/src/ics-to-json-converter.ts
@@ -20,6 +20,9 @@ interface Event {
 const ICAL = require("ical.js");
 const outputType = "application/json";
 
+/**
+ * Converts an ICS representation to JSON
+ */
 export class IcsToJsonConverter extends TypedRepresentationConverter {
   public constructor() {
     super("text/calendar", outputType);

--- a/src/ics-to-json-converter.ts
+++ b/src/ics-to-json-converter.ts
@@ -32,7 +32,7 @@ export class IcsToJsonConverter extends TypedRepresentationConverter {
     const data = await readableToString(representation.data);
     const events: Event[] = [];
 
-    if (!data || !data.length)
+    if (!data?.length)
       throw new BadRequestHttpError("Empty input is not allowed");
 
     const jcalData = ICAL.parse(data);
@@ -75,7 +75,7 @@ export class IcsToJsonConverter extends TypedRepresentationConverter {
       events,
     };
 
-    if (!calendar || !calendar.name || !calendar.name.trim().length)
+    if (!calendar?.name?.trim().length)
       throw new InternalServerError("No calendar name found");
 
     return new BasicRepresentation(

--- a/src/json-to-ics-converter.ts
+++ b/src/json-to-ics-converter.ts
@@ -18,6 +18,9 @@ interface Event {
   location?: string;
 }
 
+/**
+ * Converts a JSON representation to ICS
+ */
 export class JsonToIcsConverter extends TypedRepresentationConverter {
   public constructor() {
     super("application/json", outputType);

--- a/src/transformation-store.ts
+++ b/src/transformation-store.ts
@@ -14,6 +14,9 @@ import { HttpGetStore } from "./http-get-store";
 
 const outputType = "application/json";
 
+/**
+ * Transforms the events of a calendar based upon a YAML settings file.
+ */
 export class TransformationStore extends PassthroughStore<HttpGetStore> {
   private rules: string[];
   private readonly settingsPaths: string[];

--- a/src/transformation-store.ts
+++ b/src/transformation-store.ts
@@ -24,7 +24,7 @@ export class TransformationStore extends PassthroughStore<HttpGetStore> {
   ) {
     super(source);
 
-    this.rules = options.rules ? options.rules : [];
+    this.rules = options.rules ?? [];
     this.settingsPaths = options.settingsPaths;
   }
 
@@ -111,11 +111,10 @@ export class TransformationStore extends PassthroughStore<HttpGetStore> {
       await fs.readFile(path.resolve(process.cwd(), settingPath), "utf8")
     );
 
-    if (transformation) {
-      if (!this.rules.length)
-        transformation = this._allRulesObjectToArray(transformation);
-      else transformation = this._selectedRulesObjectToArray(transformation);
-    }
+    if (transformation)
+      transformation = !this.rules.length
+        ? this._allRulesObjectToArray(transformation)
+        : this._selectedRulesObjectToArray(transformation);
 
     return transformation || [];
   }

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -55,7 +55,9 @@ describe("calendar", () => {
         availabilitySlots,
         minimumSlotDuration,
         now,
-        allSlots
+        {
+          slots: allSlots,
+        }
       );
       //console.log(slots);
       assert.deepStrictEqual(slots.length, 4);
@@ -114,7 +116,9 @@ describe("calendar", () => {
         availabilitySlots,
         minimumSlotDuration,
         now,
-        allSlots
+        {
+          slots: allSlots,
+        }
       );
       //console.log(slots);
       assert.deepStrictEqual(slots.length, 4);
@@ -201,9 +205,10 @@ describe("calendar", () => {
         availabilitySlots,
         minimumSlotDuration,
         now,
-        undefined,
-        startDate,
-        endDate
+        {
+          startDate,
+          endDate,
+        }
       );
 
       const expectedResult = [

--- a/test/configs/test-aggregate-name-config.json
+++ b/test/configs/test-aggregate-name-config.json
@@ -1,22 +1,22 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AggregateStore",
+      "@id": "solid-calendar-store:AggregateStore",
       "AggregateStore:_options_name": "Custom calendar name"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml"
     }
   ]

--- a/test/configs/test-alternate-config.json
+++ b/test/configs/test-alternate-config.json
@@ -13,15 +13,20 @@
     },
     {
       "@id": "solid-calendar-store:AvailabilityStore",
-      "AvailabilityStore:_options_settingsPath": "test/configs/test-weekend-settings.yaml"
+      "AvailabilityStore:_options_settingsPath": "test/configs/test-timezone-settings.yaml",
+      "AvailabilityStore:_options_startDate": "2021-06-24T07:47:29.182Z"
     },
     {
       "@id": "solid-calendar-store:BusyStore",
-      "TransformationStore:_options_settingsPaths": ["test/configs/empty-settings.yaml"]
+      "TransformationStore:_options_settingsPaths": ["test/configs/test-settings.yaml"]
+    },
+    {
+      "@id": "solid-calendar-store:TransformationStore",
+      "TransformationStore:_options_settingsPaths": ["test/configs/test-settings.yaml"]
     },
     {
       "@id": "solid-calendar-store:HolidayStore",
-      "HolidayStore:_options_configPath": "test/configs/empty-holidays.json"
+      "HolidayStore:_options_configPath": "test/configs/holidays.json"
     }
   ]
 }

--- a/test/configs/test-config.json
+++ b/test/configs/test-config.json
@@ -1,31 +1,31 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml",
       "AvailabilityStore:_options_startDate": "2021-06-24T07:47:29.182Z"
     },
     {
-      "@id": "solid-calendar:BusyStore",
+      "@id": "solid-calendar-store:BusyStore",
       "TransformationStore:_options_settingsPaths": ["test/configs/test-settings.yaml"]
     },
     {
-      "@id": "solid-calendar:TransformationStore",
+      "@id": "solid-calendar-store:TransformationStore",
       "TransformationStore:_options_settingsPaths": ["test/configs/test-settings.yaml"]
     },
     {
-      "@id": "solid-calendar:HolidayStore",
+      "@id": "solid-calendar-store:HolidayStore",
       "HolidayStore:_options_configPath": "test/configs/holidays.json"
     }
   ]

--- a/test/configs/test-empty-config.json
+++ b/test/configs/test-empty-config.json
@@ -1,27 +1,27 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml",
       "AvailabilityStore:_options_startDate": "2021-06-24T07:47:29.182Z"
     },
     {
-      "@id": "solid-calendar:BusyStore",
+      "@id": "solid-calendar-store:BusyStore",
       "TransformationStore:_options_settingsPaths": ["test/configs/empty-settings.yaml"]
     },
     {
-      "@id": "solid-calendar:HolidayStore",
+      "@id": "solid-calendar-store:HolidayStore",
       "HolidayStore:_options_configPath": "test/configs/empty-holidays.json"
     }
   ]

--- a/test/configs/test-holiday-config.json
+++ b/test/configs/test-holiday-config.json
@@ -1,24 +1,24 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml",
       "AvailabilityStore:_options_startDate": "2021-12-31T07:47:29.182Z",
-      "AvailabilityStore:_options_holidaySource": { "@id": "solid-calendar:HolidayStore" }
+      "AvailabilityStore:_options_holidaySource": { "@id": "solid-calendar-store:HolidayStore" }
     },
     {
-      "@id": "solid-calendar:HolidayStore",
+      "@id": "solid-calendar-store:HolidayStore",
       "HolidayStore:_options_configPath": "test/configs/holidays.json"
     }
   ]

--- a/test/configs/test-incorrect-config.json
+++ b/test/configs/test-incorrect-config.json
@@ -1,22 +1,22 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml"
     },
     {
-      "@id": "solid-calendar:HolidayStore",
+      "@id": "solid-calendar-store:HolidayStore",
       "HolidayStore:_options_configPath": "not-existing.json"
     }
   ]

--- a/test/configs/test-no-startDate-config.json
+++ b/test/configs/test-no-startDate-config.json
@@ -1,18 +1,18 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml"
     }
   ]

--- a/test/configs/test-remove-fields-config.json
+++ b/test/configs/test-remove-fields-config.json
@@ -1,27 +1,27 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml",
       "AvailabilityStore:_options_startDate": "2021-06-24T07:47:29.182Z"
     },
     {
-      "@id": "solid-calendar:BusyStore",
+      "@id": "solid-calendar-store:BusyStore",
       "TransformationStore:_options_settingsPaths": ["test/configs/test-settings.yaml"]
     },
     {
-      "@id": "solid-calendar:TransformationStore",
+      "@id": "solid-calendar-store:TransformationStore",
       "TransformationStore:_options_settingsPaths": ["test/configs/test-remove-fields-settings.yaml"]
     }
   ]

--- a/test/configs/test-timezone-settings.yaml
+++ b/test/configs/test-timezone-settings.yaml
@@ -1,0 +1,9 @@
+availabilitySlots:
+  - startTime:
+      hour: 9
+      minutes: 0
+    endTime:
+      hour: 10
+      minutes: 0
+minimumSlotDuration: 30
+timezone: "America/Bahia"

--- a/test/configs/test-weekend-config.json
+++ b/test/configs/test-weekend-config.json
@@ -1,18 +1,18 @@
 {
   "@context": [
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar/^0.0.0/components/context.jsonld",
-    { "solid-calendar": "urn:solid-calendar:default:" }
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-calendar-store/^0.0.0/components/context.jsonld",
+    { "solid-calendar-store": "urn:solid-calendar-store:default:" }
   ],
   "import": [
-    "files-sc:config/config-calendar.json"
+    "files-scs:config/config-calendar.json"
   ],
   "@graph": [
     {
-      "@id": "solid-calendar:HttpGetStore",
+      "@id": "solid-calendar-store:HttpGetStore",
       "HttpGetStore:_options_url": "http://localhost:3001"
     },
     {
-      "@id": "solid-calendar:AvailabilityStore",
+      "@id": "solid-calendar-store:AvailabilityStore",
       "AvailabilityStore:_options_settingsPath": "test/configs/test-settings.yaml",
       "AvailabilityStore:_options_startDate": "2021-06-26T07:47:29.182Z"
     }

--- a/test/configs/test-weekend-settings.yaml
+++ b/test/configs/test-weekend-settings.yaml
@@ -1,0 +1,9 @@
+availabilitySlots:
+  - startTime:
+      hour: 9
+      minutes: 0
+    endTime:
+      hour: 10
+      minutes: 0
+minimumSlotDuration: 30
+weekend: [0, 1, 2, 3, 4, 5, 6]

--- a/test/stores/common.ts
+++ b/test/stores/common.ts
@@ -29,3 +29,4 @@ export const incorrectConfig = "./test/configs/test-incorrect-config.json";
 export const noStartDateConfig = "./test/configs/test-no-startDate-config.json";
 export const weekendConfig = "./test/configs/test-weekend-config.json";
 export const holidayConfig = "./test/configs/test-holiday-config.json";
+export const alternateConfig = "./test/configs/test-alternate-config.json";


### PR DESCRIPTION
The urls have been rewritten to account for the repository name change, documentation has been added and AvailabilityStore is now worldwide usable.

Regarding the class documentation, these are deliberately kept short to encourage looking at explanations in `docs/`.

Solves #1 and #2.